### PR TITLE
Fix chronos binary location

### DIFF
--- a/chronos/chronos-template
+++ b/chronos/chronos-template
@@ -7,4 +7,4 @@ RUN rm -rf /etc/chronos/conf
 
 EXPOSE 4400
 
-CMD ["/usr/local/bin/chronos", "run_jar", "--http_port", "4400", "--zk_hosts",  "localhost:2181", "--master", "zk://localhost:2181"]
+CMD ["/usr/bin/chronos", "run_jar", "--http_port", "4400", "--zk_hosts",  "localhost:2181", "--master", "zk://localhost:2181"]


### PR DESCRIPTION
The Chronos binary seems to be located at `/usr/bin/chronos` rather than `/usr/local/bin/chronos` inside the container.

```
Status: Downloaded newer image for mesosphere/chronos:latest
 ~  docker run -it mesosphere/chronos bash
root@08407c31998b:/usr/local/bin# find / -name 'chronos'
/etc/chronos
/etc/init.d/chronos
/usr/bin/chronos
/usr/share/doc/chronos
```

It would be helpful if the Usage section of the docker hub repo could be updated as well:
https://registry.hub.docker.com/u/mesosphere/chronos/