### PR TITLE
Add mesos-slave-dind image

### DIFF
--- a/mesos-slave-dind/Makefile
+++ b/mesos-slave-dind/Makefile
@@ -1,0 +1,39 @@
+all: help
+
+help:
+	@echo 'Options available:'
+	@echo '  make images VERSION=0.23.0-1.0.ubuntu1404.docker181 MESOS_VERSION=0.23.0-1.0.ubuntu1404 DOCKER_VERSION=1.8.1-0~trusty'
+	@echo '  make push   VERSION=0.23.0-1.0.ubuntu1404.docker181'
+	@echo ''
+	@echo 'VERSION should include the Mesos, Ubuntu, and Docker versions'
+	@echo 'DOCKER_VERSION should be the docker-engine version to install with apt-get (>= 1.8.0)'
+
+check-version:
+ifndef VERSION
+	@echo "Error: VERSION is undefined."
+	@make --no-print-directory help
+	@exit 1
+endif
+
+check-mesos-version:
+ifndef MESOS_VERSION
+	@echo "Error: MESOS_VERSION is undefined."
+	@make --no-print-directory help
+	@exit 1
+endif
+
+check-docker-version:
+ifndef DOCKER_VERSION
+	@echo "Error: DOCKER_VERSION is undefined."
+	@make --no-print-directory help
+	@exit 1
+endif
+
+images: check-version mesos-slave-dind
+
+push: check-version
+	docker push mesosphere/mesos-slave-dind:$(VERSION)
+
+mesos-slave-dind: check-version check-mesos-version check-docker-version
+	sed "s/DOCKER_VERSION/$(DOCKER_VERSION)/g;s/MESOS_VERSION/$(MESOS_VERSION)/g" dockerfile-templates/$@ > $@
+	docker build -t mesosphere/$@:$(VERSION) -f $@ .

--- a/mesos-slave-dind/README.md
+++ b/mesos-slave-dind/README.md
@@ -1,0 +1,29 @@
+### Mesos Slave Docker-in-Docker (dind)
+
+Mesos-Slave that runs in a Ubuntu-based Docker container.
+
+Launches tasks using the included Docker Engine, rather than the host's Docker Engine.
+
+#### Features
+
+- Runs Mesos tasks inside the container (instead of in the parent Docker env).
+- Mesos tasks (in docker containers) are stopped when the mesos-slave-dind container is stopped.
+- Supports OverlayFS (new hotness) and AUFS (legacy)
+  - Allocates disk space (via loop mount) to allow mounting AUFS on AUFS
+- Allocates IP space on the parent Docker's network, making docker-in-docker containers IP accessible from the host.
+
+#### Required Docker Parameters
+
+- `--privileged=true` - Provides access to cgroups
+
+#### Recommended Environment Variables
+
+- **MESOS_CONTAINERIZERS** - Include docker to enable running tasks as docker containers. Ex: `docker,mesos`
+- **MESOS_RESOURCES** - Specify resources to avoid oversubscribing via auto-detecting host resources. Ex: `cpus:4;mem:1280;disk:25600;ports:[21000-21099]`
+- **DOCKER_NETWORK_OFFSET** - Specify an IP offset to give each mesos-slave-dind container (default: `0.0.1.0`). Ex: `0.0.1.0` (slave A), `0.0.2.0` (slave B)
+- **DOCKER_NETWORK_SIZE** - Specify a CIDR range to apply to the above offset (default=`24`).
+- **VAR_LIB_DOCKER_SIZE** - Specify the max size (in GB) of the loop device to be mounted at /var/lib/docker (default=`5`). This is only used if OverlayFS is not supported by the kernel or the parent docker is configured to use AUFS.
+
+Source: <https://github.com/mesosphere/docker-containers/tree/master/mesos-slave-dind>
+
+Inspiration: <https://github.com/jpetazzo/dind>

--- a/mesos-slave-dind/dockerfile-templates/mesos-slave-dind
+++ b/mesos-slave-dind/dockerfile-templates/mesos-slave-dind
@@ -1,0 +1,31 @@
+FROM mesosphere/mesos-slave:MESOS_VERSION
+MAINTAINER Mesosphere <support@mesosphere.io>
+
+RUN apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -qqy \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        lxc \
+        iptables \
+        ipcalc \
+        && \
+    apt-get clean
+
+# Install latest Docker
+# RUN curl -sSL https://get.docker.com/ubuntu/ | sh
+
+# Install Docker 1.8.1 explicitly
+RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
+    mkdir -p /etc/apt/sources.list.d && \
+    echo deb https://apt.dockerproject.org/repo ubuntu-trusty main > /etc/apt/sources.list.d/docker.list && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -qqy \
+        docker-engine=DOCKER_VERSION \
+        && \
+    apt-get clean
+
+COPY ./wrapdocker /usr/local/bin/
+
+ENTRYPOINT ["wrapdocker"]
+CMD ["mesos-slave"]

--- a/mesos-slave-dind/wrapdocker
+++ b/mesos-slave-dind/wrapdocker
@@ -1,0 +1,182 @@
+#!/bin/bash
+
+# Copyright 2013-2015 Jérôme Petazzoni, Johan Haleby, lalyos, James Harris,
+#                     Michael Elsdörfer, Tony Hesjevik, Esben Haabendal,
+#                     Michael A. Smith, Stefan Schimanski, Karl Isenberg
+# Original source: https://github.com/jpetazzo/dind
+# Modified to add docker network reservations.
+
+# Ensure that all nodes in /dev/mapper correspond to mapped devices currently loaded by the device-mapper kernel driver
+dmsetup mknodes
+
+# First, make sure that cgroups are mounted correctly.
+CGROUP=/sys/fs/cgroup
+: {LOG:=stdio}
+
+[ -d $CGROUP ] ||
+	mkdir $CGROUP
+
+mountpoint -q $CGROUP ||
+	mount -n -t tmpfs -o uid=0,gid=0,mode=0755 cgroup $CGROUP || {
+		echo "Could not make a tmpfs mount. Did you use --privileged?"
+		exit 1
+	}
+
+if [ -d /sys/kernel/security ] && ! mountpoint -q /sys/kernel/security
+then
+    mount -t securityfs none /sys/kernel/security || {
+        echo "Could not mount /sys/kernel/security."
+        echo "AppArmor detection and --privileged mode might break."
+    }
+fi
+
+# Mount the cgroup hierarchies exactly as they are in the parent system.
+for SUBSYS in $(cut -d: -f2 /proc/1/cgroup)
+do
+        [ -d $CGROUP/$SUBSYS ] || mkdir $CGROUP/$SUBSYS
+        mountpoint -q $CGROUP/$SUBSYS ||
+                mount -n -t cgroup -o $SUBSYS cgroup $CGROUP/$SUBSYS
+
+        # The two following sections address a bug which manifests itself
+        # by a cryptic "lxc-start: no ns_cgroup option specified" when
+        # trying to start containers withina container.
+        # The bug seems to appear when the cgroup hierarchies are not
+        # mounted on the exact same directories in the host, and in the
+        # container.
+
+        # Named, control-less cgroups are mounted with "-o name=foo"
+        # (and appear as such under /proc/<pid>/cgroup) but are usually
+        # mounted on a directory named "foo" (without the "name=" prefix).
+        # Systemd and OpenRC (and possibly others) both create such a
+        # cgroup. To avoid the aforementioned bug, we symlink "foo" to
+        # "name=foo". This shouldn't have any adverse effect.
+        echo $SUBSYS | grep -q ^name= && {
+                NAME=$(echo $SUBSYS | sed s/^name=//)
+                ln -s $SUBSYS $CGROUP/$NAME
+        }
+
+        # Likewise, on at least one system, it has been reported that
+        # systemd would mount the CPU and CPU accounting controllers
+        # (respectively "cpu" and "cpuacct") with "-o cpuacct,cpu"
+        # but on a directory called "cpu,cpuacct" (note the inversion
+        # in the order of the groups). This tries to work around it.
+        [ $SUBSYS = cpuacct,cpu ] && ln -s $SUBSYS $CGROUP/cpu,cpuacct
+done
+
+# Note: as I write those lines, the LXC userland tools cannot setup
+# a "sub-container" properly if the "devices" cgroup is not in its
+# own hierarchy. Let's detect this and issue a warning.
+grep -q :devices: /proc/1/cgroup ||
+	echo "WARNING: the 'devices' cgroup should be in its own hierarchy."
+grep -qw devices /proc/1/cgroup ||
+	echo "WARNING: it looks like the 'devices' cgroup is not mounted."
+
+# Now, close extraneous file descriptors.
+pushd /proc/self/fd >/dev/null
+for FD in *
+do
+	case "$FD" in
+	# Keep stdin/stdout/stderr
+	[012])
+		;;
+	# Nuke everything else
+	*)
+		eval exec "$FD>&-"
+		;;
+	esac
+done
+popd >/dev/null
+
+# find supported filesystem to use for docker image mounts
+if grep -q overlay /proc/filesystems; then
+    STORAGE_FS=overlay
+elif grep -q aufs /proc/filesystems; then
+    STORAGE_FS=aufs
+else
+    echo "No supported filesystem found (aufs, overlay)"
+    exit 1
+fi
+
+# find filesystem below /var/lib/docker
+STORAGE_DIR="/var/lib/docker"
+mkdir -p "${STORAGE_DIR}"
+STORAGE_DIR_FS=$(df -PTh "${STORAGE_DIR}" | awk '{print $2}' | tail -1)
+
+# Unless using overlay over overlay, create an ext3 loop device as an intermediary layer.
+# The max size of the loop device is $VAR_LIB_DOCKER_SIZE in GB (default=5).
+if [ "${STORAGE_DIR_FS}" != "overlay" ] || [ "${STORAGE_FS}" != "overlay" ]; then
+    STORAGE_FILE="/data/docker"
+    VAR_LIB_DOCKER_SIZE=${VAR_LIB_DOCKER_SIZE:-5}
+    mkdir -p "$(dirname "${STORAGE_FILE}")"
+    if [ ! -f "${STORAGE_FILE}" ]; then
+        dd if=/dev/zero of="${STORAGE_FILE}" bs=1G seek=${VAR_LIB_DOCKER_SIZE} count=0
+        echo y | mkfs.ext3 "${STORAGE_FILE}"
+    fi
+    mount -o loop "${STORAGE_FILE}" "${STORAGE_DIR}"
+fi
+
+# If a pidfile is still around (for example after a container restart),
+# delete it so that docker can start.
+rm -rf /var/run/docker.pid
+
+# create docker0 bridge manually and attach it to the veth interface eth0
+brctl addbr docker0
+brctl addif docker0 eth0
+ip link set docker0 up
+
+# move ip to the bridge and restore routing via the old gateway
+IP_CIDR=$(ip addr show eth0 | grep -w inet | awk '{ print $2; }')
+IP=$(echo $IP_CIDR | sed 's,/.*,,')
+NETWORK_SIZE=$(echo $IP_CIDR | sed 's,.*/,,')
+DEFAULT_ROUTE=$(ip route | grep default | sed 's/eth0/docker0/')
+
+ip addr del $IP_CIDR dev eth0
+ip addr add $IP_CIDR dev docker0
+ip route add $DEFAULT_ROUTE
+
+
+# compute a network for the containers to live in
+# by adding DOCKER_NETWORK_OFFSET to the current IP and cutting off
+# non-network bits according to DOCKER_NETWORK_SIZE
+DOCKER_NETWORK_SIZE=${DOCKER_NETWORK_SIZE:-24}
+DOCKER_NETWORK_OFFSET=${DOCKER_NETWORK_OFFSET:-0.0.1.0}
+NETWORK=$(ip route | grep docker0 | grep -v default | sed 's,/.*,,')
+
+IFS=. read -r i1 i2 i3 i4 <<< $IP
+IFS=. read -r n1 n2 n3 n4 <<< $NETWORK
+IFS=. read -r o1 o2 o3 o4 <<< $DOCKER_NETWORK_OFFSET
+IFS=. read -r w1 w2 w3 w4 <<< $(ipcalc $IP_CIDR | grep Wildcard | awk '{print $2;}')
+
+IP_PLUS_OFFSET=$(printf "%d.%d.%d.%d\n" \
+    "$(( n1 + ((i1 - n1 + o1) & w1) ))" \
+    "$(( n2 + ((i2 - n2 + o2) & w2) ))" \
+    "$(( n3 + ((i3 - n3 + o3) & w3) ))" \
+    "$(( n4 + ((i4 - n4 + o4) & w4) ))")
+
+FIXED_CIDR=$(ipcalc $IP_PLUS_OFFSET/$DOCKER_NETWORK_SIZE | grep Network | awk '{print $2;}')
+echo "Using network $FIXED_CIDR for docker containers"
+
+# stop docker daemon on shutdown to avoid loopback leaks
+trap "service docker stop" EXIT
+
+# let docker reuse the given IP. If you run more than one dind slave, add
+# --fixed-cidr=a.b.c.d/24 to DOCKER_DAEMON_ARGS with disjunct networks.
+DOCKER_DAEMON_ARGS="${DOCKER_DAEMON_ARGS} --bip=${IP_CIDR} --fixed-cidr=${FIXED_CIDR} --storage-driver=${STORAGE_FS}"
+
+# start docker daemon
+if [ "$LOG" == "file" ]; then
+	docker daemon ${DOCKER_DAEMON_ARGS} &>/var/log/docker.log &
+else
+	docker daemon ${DOCKER_DAEMON_ARGS} &
+fi
+(( timeout = 60 + SECONDS ))
+until docker info >/dev/null 2>&1
+do
+	if (( SECONDS >= timeout )); then
+		echo 'Timed out trying to connect to internal docker host.' >&2
+		exit 1
+	fi
+	sleep 1
+done
+[[ $1 ]] && exec "$@"
+exec bash --login


### PR DESCRIPTION
- Allows for running mesos tasks with docker-in-docker
- Allocates network space for the dind containers in the parent docker network

Planned use: Kubernetes development cluster

The best part? When you kill a slave container, all the tasks it spawned die too, just like they would in a VM.