### PR TITLE
mesos-slave-dind: install socat and nsenter for kubernetes compatibility

### DIFF
--- a/mesos-slave-dind/.gitignore
+++ b/mesos-slave-dind/.gitignore
@@ -1,0 +1,1 @@
+downloads

--- a/mesos-slave-dind/Makefile
+++ b/mesos-slave-dind/Makefile
@@ -2,18 +2,13 @@ all: help
 
 help:
 	@echo 'Options available:'
-	@echo '  make images VERSION=0.23.0-1.0.ubuntu1404.docker181 MESOS_VERSION=0.23.0-1.0.ubuntu1404 DOCKER_VERSION=1.8.1-0~trusty'
-	@echo '  make push   VERSION=0.23.0-1.0.ubuntu1404.docker181'
+	@echo '  make images MESOS_VERSION=0.23.0-1.0.ubuntu1404 DOCKER_VERSION=1.8.1-0~trusty'
+	@echo '  make push   MESOS_VERSION=0.23.0-1.0.ubuntu1404 DOCKER_VERSION=1.8.1-0~trusty'
 	@echo ''
-	@echo 'VERSION should include the Mesos, Ubuntu, and Docker versions'
+	@echo 'MESOS_VERSION is the mesos base image version'
 	@echo 'DOCKER_VERSION should be the docker-engine version to install with apt-get (>= 1.8.0)'
 
 check-version:
-ifndef VERSION
-	@echo "Error: VERSION is undefined."
-	@make --no-print-directory help
-	@exit 1
-endif
 
 check-mesos-version:
 ifndef MESOS_VERSION
@@ -28,6 +23,8 @@ ifndef DOCKER_VERSION
 	@make --no-print-directory help
 	@exit 1
 endif
+
+VERSION=mesos-$(MESOS_VERSION)-docker-$(subst ~,-,$(DOCKER_VERSION))
 
 images: check-version mesos-slave-dind
 

--- a/mesos-slave-dind/Makefile
+++ b/mesos-slave-dind/Makefile
@@ -34,6 +34,10 @@ images: check-version mesos-slave-dind
 push: check-version
 	docker push mesosphere/mesos-slave-dind:$(VERSION)
 
-mesos-slave-dind: check-version check-mesos-version check-docker-version
+downloads/nsenter:
+	mkdir -p downloads
+	docker run --rm -v $$PWD/downloads:/target jpetazzo/nsenter
+
+mesos-slave-dind: check-version check-mesos-version check-docker-version downloads/nsenter
 	sed "s/DOCKER_VERSION/$(DOCKER_VERSION)/g;s/MESOS_VERSION/$(MESOS_VERSION)/g" dockerfile-templates/$@ > $@
 	docker build -t mesosphere/$@:$(VERSION) -f $@ .

--- a/mesos-slave-dind/dockerfile-templates/mesos-slave-dind
+++ b/mesos-slave-dind/dockerfile-templates/mesos-slave-dind
@@ -26,6 +26,7 @@ RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 581
     apt-get clean
 
 COPY ./wrapdocker /usr/local/bin/
+COPY ./downloads/* /usr/local/bin/
 
 ENTRYPOINT ["wrapdocker"]
 CMD ["mesos-slave"]

--- a/mesos-slave-dind/dockerfile-templates/mesos-slave-dind
+++ b/mesos-slave-dind/dockerfile-templates/mesos-slave-dind
@@ -9,6 +9,7 @@ RUN apt-get update -qq && \
         lxc \
         iptables \
         ipcalc \
+        socat \
         && \
     apt-get clean
 


### PR DESCRIPTION
For port-forwarding the Kubernetes kubelet needs socat and nsenter.