### PR TITLE
mesos-slave-dind: make build reproducible

### DIFF
--- a/mesos-slave-dind/Makefile
+++ b/mesos-slave-dind/Makefile
@@ -2,18 +2,13 @@ all: help
 
 help:
 	@echo 'Options available:'
-	@echo '  make images VERSION=0.23.0-1.0.ubuntu1404.docker181 MESOS_VERSION=0.23.0-1.0.ubuntu1404 DOCKER_VERSION=1.8.1-0~trusty'
-	@echo '  make push   VERSION=0.23.0-1.0.ubuntu1404.docker181'
+	@echo '  make images MESOS_VERSION=0.23.0-1.0.ubuntu1404 DOCKER_VERSION=1.8.1-0~trusty'
+	@echo '  make push   MESOS_VERSION=0.23.0-1.0.ubuntu1404 DOCKER_VERSION=1.8.1-0~trusty'
 	@echo ''
-	@echo 'VERSION should include the Mesos, Ubuntu, and Docker versions'
+	@echo 'MESOS_VERSION is the mesos base image version'
 	@echo 'DOCKER_VERSION should be the docker-engine version to install with apt-get (>= 1.8.0)'
 
 check-version:
-ifndef VERSION
-	@echo "Error: VERSION is undefined."
-	@make --no-print-directory help
-	@exit 1
-endif
 
 check-mesos-version:
 ifndef MESOS_VERSION
@@ -28,6 +23,8 @@ ifndef DOCKER_VERSION
 	@make --no-print-directory help
 	@exit 1
 endif
+
+VERSION=mesos-$(MESOS_VERSION)-docker-$(subst ~,-,$(DOCKER_VERSION))
 
 images: check-version mesos-slave-dind
 

--- a/mesos-slave-dind/Makefile
+++ b/mesos-slave-dind/Makefile
@@ -7,6 +7,8 @@ help:
 	@echo ''
 	@echo 'MESOS_VERSION is the mesos base image version'
 	@echo 'DOCKER_VERSION should be the docker-engine version to install with apt-get (>= 1.8.0)'
+	@echo 'ORG is the docker hub organisation, defaulting to "mesosphere"'
+
 
 check-version:
 
@@ -24,13 +26,14 @@ ifndef DOCKER_VERSION
 	@exit 1
 endif
 
+ORG=mesosphere
 VERSION=mesos-$(MESOS_VERSION)-docker-$(subst ~,-,$(DOCKER_VERSION))
 
 images: check-version mesos-slave-dind
 
 push: check-version
-	docker push mesosphere/mesos-slave-dind:$(VERSION)
+	docker push $(ORG)/mesos-slave-dind:$(VERSION)
 
 mesos-slave-dind: check-version check-mesos-version check-docker-version
 	sed "s/DOCKER_VERSION/$(DOCKER_VERSION)/g;s/MESOS_VERSION/$(MESOS_VERSION)/g" dockerfile-templates/$@ > $@
-	docker build -t mesosphere/$@:$(VERSION) -f $@ .
+	docker build -t $(ORG)/$@:$(VERSION) -f $@ .


### PR DESCRIPTION
With a free text version string, the build is not reproducible. With the generated
string, one knows the exact versions needed to rebuild the image.