### PR TITLE
Optimize Mesos image.

### DIFF
--- a/mesos/dockerfile-templates/mesos
+++ b/mesos/dockerfile-templates/mesos
@@ -1,7 +1,8 @@
 FROM ubuntu:14.04
 MAINTAINER Mesosphere <support@mesosphere.io>
 
-RUN echo "deb http://repos.mesosphere.io/ubuntu/ trusty main" > /etc/apt/sources.list.d/mesosphere.list
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF
-RUN apt-get -y update
-RUN apt-get -y install mesos=VERSION
+RUN echo "deb http://repos.mesosphere.io/ubuntu/ trusty main" > /etc/apt/sources.list.d/mesosphere.list && \
+  apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
+  apt-get -y update && \
+  apt-get -y install mesos=VERSION && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Use 1 RUN step to limit layers, and remove apt cache.

cc @cmaloney @lingmann 