### PR TITLE
Added jq+curl docker

### DIFF
--- a/utils/json-get/Dockerfile
+++ b/utils/json-get/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:3.1
+MAINTAINER Mesosphere, Inc. <support@mesosphere.io>
+
+RUN apk add --update bash curl jq \
+  && rm -rf /var/cache/apk/*
+

--- a/utils/json-get/Makefile
+++ b/utils/json-get/Makefile
@@ -1,0 +1,6 @@
+
+.PHONY: build
+build:
+	docker build -t mesosphere/json-get .
+push:
+	docker push mesosphere/json-get

--- a/utils/json-get/README.md
+++ b/utils/json-get/README.md
@@ -1,0 +1,4 @@
+# JSON Get Docker Image [![Build Status](https://teamcity.mesosphere.io/guestAuth/app/rest/builds/buildType:(id:Oss_Docker_2_MesosphereJsonGet)/statusIcon)](https://teamcity.mesosphere.io/viewType.html?buildTypeId=Oss_Docker_2_MesosphereJsonGet&guest=1)
+
+
+This adds a minimal docker which is guaranteed to have jq and curl available. Handy for polling Marathon instances from shell scripts.


### PR DESCRIPTION
This adds a minimal docker which is guaranteed to have `jq` and `curl` available. Handy for polling Marathon instances from shell scripts. 

