### PR TITLE
Add dnsutils package to mesosphere/spark for service discovery

### DIFF
--- a/spark/Dockerfile
+++ b/spark/Dockerfile
@@ -27,7 +27,7 @@ ENV DEBCONF_NONINTERACTIVE_SEEN "true"
 
 # Upgrade package index and install basic commands.
 RUN apt-get update && \
-    apt-get install -y openjdk-7-jdk curl
+    apt-get install -y openjdk-7-jdk curl dnsutils
 
 ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
 


### PR DESCRIPTION
It would be very nice to have dnsutils installed in the mesosphere/spark container. This would make possible to do service discovery using mesos-dns or consul. This would enable the users to submit this kind of commands through Chronos:

```
MASTER_PORT=$(dig +short spark-dispatcher.service.consul SRV | awk '{print $3}' | sort | head -1) && \
bin/spark-submit --class org.apache.spark.examples.SparkPi \ 
--master mesos://spark-dispatcher.service.consul:$MASTER_PORT \
--deploy-mode cluster \
/mnt/container-volumes/spark-1.6.0-bin-hadoop2.4/lib/spark-examples-1.6.0-hadoop2.4.0.jar \
1000
```