### PR TITLE
Provide short version for docker images tags

### DIFF
--- a/mesos/Makefile
+++ b/mesos/Makefile
@@ -1,3 +1,4 @@
+SHORT_VERSION=`echo "$(VERSION)" | sed -E "s|^(.*)-(.*)$$|\1|"`
 all: help
 
 help:
@@ -18,17 +19,23 @@ images: check-version mesos mesos-master mesos-slave
 
 push: check-version
 	docker push mesosphere/mesos:$(VERSION)
+	docker push mesosphere/mesos:$(SHORT_VERSION)
 	docker push mesosphere/mesos-master:$(VERSION)
+	docker push mesosphere/mesos-master:$(SHORT_VERSION)
 	docker push mesosphere/mesos-slave:$(VERSION)
+	docker push mesosphere/mesos-slave:$(SHORT_VERSION)
 
 mesos: check-version
 	sed "s/VERSION/$(VERSION)/g" dockerfile-templates/$@ > $@
 	docker build -t mesosphere/$@:$(VERSION) - < $@
+	docker tag mesosphere/$@:$(VERSION) mesosphere/$@:$(SHORT_VERSION) < $@
 
 mesos-master: mesos check-version
 	sed "s/VERSION/$(VERSION)/g" dockerfile-templates/$@ > $@
 	docker build -t mesosphere/$@:$(VERSION) - < $@
+	docker tag mesosphere/$@:$(VERSION) mesosphere/$@:$(SHORT_VERSION) < $@
 
 mesos-slave: mesos check-version
 	sed "s/VERSION/$(VERSION)/g" dockerfile-templates/$@ > $@
 	docker build -t mesosphere/$@:$(VERSION) - < $@
+	docker tag mesosphere/$@:$(VERSION) mesosphere/$@:$(SHORT_VERSION) < $@


### PR DESCRIPTION
Currently, on https://hub.docker.com/r/mesosphere/mesos/tags/, the tags are in the form ``0.28.0-2.0.16.ubuntu1404``. 

It will be nice to also have the shorter tags in the form ``0.28.0``, that just refer to the latest minor versions.

This PR includes changes to provide those shorter tags.

cc  @brndnmtthws @ssk2 

Thanks