### PR TITLE
Add Velocity Images

### DIFF
--- a/velocity/ci-cypress
+++ b/velocity/ci-cypress
@@ -1,0 +1,22 @@
+# This is a container to run the cypress product from cypress.io.
+# It includes openjdk8 because the intention is to be run as a
+# Jenkins process.
+FROM node:4.4.3
+LABEL node-version="4.4.3" cypress-version="0.15.3"
+
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+
+# basic dependencies
+RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list
+RUN apt-get update 					\
+	&& apt-get install -y xvfb 		\
+		libgtk2.0-0 libnotify4 		\
+		libgconf-2-4 libnss3 		\
+		openjdk-8-jre-headless 		\
+		ca-certificates-java
+RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure
+
+# install cypress.
+RUN npm install -g cypress-cli		\
+	&& cypress install
+

--- a/velocity/ci-erlang
+++ b/velocity/ci-erlang
@@ -1,0 +1,30 @@
+# An erlang image that contains covertool
+FROM erlang:18.1
+LABEL version="18.1"
+
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+
+# basic dependencies
+RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list
+RUN apt-get update				\
+	&& apt-get install -y 		\
+		openjdk-8-jre-headless	\
+		ca-certificates-java
+RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure
+RUN mkdir -p /root/bin
+
+RUN mkdir -p /rebar		\
+	&& git clone https://github.com/rebar/rebar.git rebar	\
+	&& cd /rebar		\
+	&& ./bootstrap
+
+RUN mkdir -p /covertool						\
+	&& git clone https://github.com/idubrov/covertool.git /covertool	\
+	&& cd /covertool						\
+	&& /rebar/rebar get-deps update-deps	\
+	&& make -C deps/rebar					\
+	&& /rebar/rebar compile escriptize		\
+	&& mv covertool /root/bin/covertool
+
+RUN rm -rf /rebar
+


### PR DESCRIPTION
This commit adds two images for CI purposes. Both images include java8 to run Jenkins components.

* ci-cypress is nodejs 4.4.3 with the cypress-ci tool installed.
* ci-erlang is erlang/otp 18.1 with covertool installed.