### PR TITLE
Updated mesos Dockerfile to install docker-engine.

### DIFF
--- a/mesos/dockerfile-templates/mesos
+++ b/mesos/dockerfile-templates/mesos
@@ -1,6 +1,14 @@
 FROM ubuntu:14.04
 MAINTAINER Mesosphere <support@mesosphere.io>
 
+
+RUN apt-get update && \
+  apt-get -y install apt-transport-https ca-certificates && \
+  apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
+  echo deb https://apt.dockerproject.org/repo ubuntu-trusty main > /etc/apt/sources.list.d/docker.list && \
+  apt-get update && \
+  apt-get -y install docker-engine
+
 RUN echo "deb http://repos.mesosphere.io/ubuntu/ trusty main" > /etc/apt/sources.list.d/mesosphere.list && \
   apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
   apt-get -y update && \


### PR DESCRIPTION
Users have been complaining that the images can't be used with
`DockerContainerizer` due to the absence of missing Docker client in
the Mesos images. To work around this limitation users bind mount
their host docker clients into the docker images to use the
`DockerContainerizer`. The problem with this work around is that the
newer docker clients are no longer static go binaries (actually they
haven't been for a while). This results in users having to bind mount
multiple dependencies to get the docker client to work, making it
error prone.

To simplify the users experience we have decided to go ahead and
install the docker engine while creating the Mesos images. The Ubuntu
packages install the docker daemon, and the client. The daemon will
never be used but the client can be used by the container to connect
to the host daemon
(https://jpetazzo.github.io/2015/09/03/do-not-use-docker-in-docker-for-ci/).

There are a few caveats to this approach:
* Docker clients are API compatible with the docker daemon. So as long
  as the docker daemon supports the API version that the docker client
  is speaking it should just work.
* Docker clients don't seem to be backward compatible. This means that
  a new docker client will most probably not be able to talk to an
  older docker version. This probably needs to be documented.