### PR TITLE
Add 'curl' to mesos docker image

### DIFF
--- a/mesos/dockerfile-templates/mesos
+++ b/mesos/dockerfile-templates/mesos
@@ -3,7 +3,7 @@ MAINTAINER Mesosphere <support@mesosphere.io>
 
 
 RUN apt-get update && \
-  apt-get -y install apt-transport-https ca-certificates && \
+  apt-get -y install apt-transport-https ca-certificates curl && \
   apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
   echo deb https://apt.dockerproject.org/repo ubuntu-trusty main > /etc/apt/sources.list.d/docker.list && \
   apt-get update && \


### PR DESCRIPTION
I've been experimenting with running the Unified Containerizer inside a Docker Container, for demo purposes. Found that Mesos shells out to 'curl' when creating Unified Tasks:
```
E0818 00:39:07.557843    11 slave.cpp:3976] Container 'af48e158-631e-4b9a-8fb9-53b481787a40' for executor 'database.2be5771a-64dc-11e6-84fd-0242ac110005' of framework 78ff8c50-738c-4aa0-8525-74b0752ea836-0000 failed to start: Failed to perform 'curl': ABORT: (../../../../../..//tmp/mesos-build/mesos-repo/3rdparty/libprocess/include/process/posix/subprocess.hpp:306): Failed to os::execvpe on path 'curl': No such file or directory
*** Aborted at 1471480747 (unix time) try "date -d @1471480747" if you are using GNU date ***
PC: @     0x7fc2aa6c8c37 (unknown)
*** SIGABRT (@0x5f) received by PID 95 (TID 0x7fc2a1e38700) from PID 95; stack trace: ***
    @     0x7fc2aaa67330 (unknown)
    @     0x7fc2aa6c8c37 (unknown)
    @     0x7fc2aa6cc028 (unknown)
    @           0x41336c _Abort()
    @           0x4133ac _Abort()
    @     0x7fc2ac8c764e process::internal::childMain()
    @     0x7fc2ac8c654d std::_Function_handler<>::_M_invoke()
    @     0x7fc2ac8c64f3 process::internal::defaultClone()
    @     0x7fc2ac8c8055 process::internal::cloneChild()
    @     0x7fc2ac8c59a6 process::subprocess()
    @     0x7fc2ac34b723 mesos::uri::curl()
    @     0x7fc2ac34defe mesos::uri::curl()
    @     0x7fc2ac352bf4 mesos::uri::DockerFetcherPluginProcess::fetch()
    @     0x7fc2ac357887 _ZNSt17_Function_handlerIFvPN7process11ProcessBaseEEZNS0_8dispatchI7NothingN5mesos3uri26DockerFetcherPluginProcessERKNS6_3URIERKSsS9_SsEENS0_6FutureIT_EERKNS0_3PIDIT0_EEMSI_FSG_T1_T2_ET3_T4_EUlS2_E_E9_M_invokeERKSt9_Any_dataS2_
    @     0x7fc2ac891791 process::ProcessManager::resume()
    @     0x7fc2ac891a97 _ZNSt6thread5_ImplISt12_Bind_simpleIFZN7process14ProcessManager12init_threadsEvEUt_vEEE6_M_runEv
    @     0x7fc2aaf3ca60 (unknown)
    @     0x7fc2aaa5f184 start_thread
    @     0x7fc2aa78c37d (unknown)
```