### PR TITLE
Installs urllib3[secure] as recommended in the following warning:

### DIFF
--- a/utils/linkchecker/Dockerfile
+++ b/utils/linkchecker/Dockerfile
@@ -3,6 +3,7 @@ MAINTAINER Mesosphere, Inc. <support@mesosphere.io>
 
 RUN pip uninstall -y requests
 RUN apt-get install -y python-requests
+RUN pip install urllib3[secure]
 ADD http://ftp.debian.org/debian/pool/main/l/linkchecker/linkchecker_9.3-1_amd64.deb /tmp/linkchecker_9.3-1_amd64.deb
 
 RUN dpkg -i /tmp/linkchecker_9.3-1_amd64.deb


### PR DESCRIPTION
Stops the  InsecurePlatformWarning message when an ssl url is encountered.
