### PR TITLE
Bump linkchecker to 9.3-4

### DIFF
--- a/utils/linkchecker/Dockerfile
+++ b/utils/linkchecker/Dockerfile
@@ -3,6 +3,6 @@ MAINTAINER Mesosphere, Inc. <support@mesosphere.io>
 
 RUN pip uninstall -y requests
 RUN apt-get install -y python-requests
-ADD http://ftp.debian.org/debian/pool/main/l/linkchecker/linkchecker_9.3-1_amd64.deb /tmp/linkchecker_9.3-1_amd64.deb
+ADD http://ftp.debian.org/debian/pool/main/l/linkchecker/linkchecker_9.3-4_amd64.deb /tmp/linkchecker_9.3-4_amd64.deb
 
-RUN dpkg -i /tmp/linkchecker_9.3-1_amd64.deb
+RUN dpkg -i /tmp/linkchecker_9.3-4_amd64.deb


### PR DESCRIPTION
Fixes an SSL bug when testing locally against servers with no SSL cert
