### PR TITLE
openldap: fix rfc2307bis schema

### DIFF
--- a/openldap/Dockerfile.rfc2307bis
+++ b/openldap/Dockerfile.rfc2307bis
@@ -3,4 +3,5 @@ MAINTAINER Mesosphere support@mesosphere.io
 
 ADD rfc2307bis/rfc2307bis.ldif /etc/ldap/schema/
 ADD rfc2307bis/rfc2307bis.schema /etc/ldap/schema/
+ADD rfc2307bis/rfc2307bis.conf /container/service/slapd/schema/rfc2307bis.conf
 ADD rfc2307bis/startup.sh /container/service/slapd/startup.sh

--- a/openldap/rfc2307bis/rfc2307bis.conf
+++ b/openldap/rfc2307bis/rfc2307bis.conf
@@ -1,0 +1,4 @@
+include         /etc/ldap/schema/core.schema
+include         /etc/ldap/schema/cosine.schema
+include         /etc/ldap/schema/inetorgperson.schema
+include         /etc/ldap/schema/rfc2307bis.schema

--- a/openldap/rfc2307bis/rfc2307bis.ldif
+++ b/openldap/rfc2307bis/rfc2307bis.ldif
@@ -1,109 +1,158 @@
 # AUTO-GENERATED FILE - DO NOT EDIT!! Use ldapmodify.
-# CRC32 a51e5dad
+# CRC32 6b6ad917
 dn: cn=rfc2307bis,cn=schema,cn=config
 objectClass: olcSchemaConfig
-cn: {2}nis
-olcAttributeTypes: {0}( 1.3.6.1.1.1.1.2 NAME 'gecos' DESC 'The GECOS field;
- the common name' EQUALITY caseIgnoreIA5Match SUBSTR caseIgnoreIA5Substrings
- Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE )
+cn: rfc2307bis
+olcAttributeTypes: {0}( 1.3.6.1.1.1.1.2 NAME 'gecos' DESC 'The GECOS field; 
+ the common name' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch 
+ SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE )
 olcAttributeTypes: {1}( 1.3.6.1.1.1.1.3 NAME 'homeDirectory' DESC 'The absol
  ute path to the home directory' EQUALITY caseExactIA5Match SYNTAX 1.3.6.1.4
  .1.1466.115.121.1.26 SINGLE-VALUE )
-olcAttributeTypes: {2}( 1.3.6.1.1.1.1.4 NAME 'loginShell' DESC 'The path to
+olcAttributeTypes: {2}( 1.3.6.1.1.1.1.4 NAME 'loginShell' DESC 'The path to 
  the login shell' EQUALITY caseExactIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121
  .1.26 SINGLE-VALUE )
 olcAttributeTypes: {3}( 1.3.6.1.1.1.1.5 NAME 'shadowLastChange' EQUALITY int
- egerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+ egerMatch ORDERING integerOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.2
+ 7 SINGLE-VALUE )
 olcAttributeTypes: {4}( 1.3.6.1.1.1.1.6 NAME 'shadowMin' EQUALITY integerMat
- ch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+ ch ORDERING integerOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGL
+ E-VALUE )
 olcAttributeTypes: {5}( 1.3.6.1.1.1.1.7 NAME 'shadowMax' EQUALITY integerMat
- ch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+ ch ORDERING integerOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGL
+ E-VALUE )
 olcAttributeTypes: {6}( 1.3.6.1.1.1.1.8 NAME 'shadowWarning' EQUALITY intege
- rMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+ rMatch ORDERING integerOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 S
+ INGLE-VALUE )
 olcAttributeTypes: {7}( 1.3.6.1.1.1.1.9 NAME 'shadowInactive' EQUALITY integ
- erMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+ erMatch ORDERING integerOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 
+ SINGLE-VALUE )
 olcAttributeTypes: {8}( 1.3.6.1.1.1.1.10 NAME 'shadowExpire' EQUALITY intege
- rMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+ rMatch ORDERING integerOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 S
+ INGLE-VALUE )
 olcAttributeTypes: {9}( 1.3.6.1.1.1.1.11 NAME 'shadowFlag' EQUALITY integerM
- atch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+ atch ORDERING integerOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SIN
+ GLE-VALUE )
 olcAttributeTypes: {10}( 1.3.6.1.1.1.1.12 NAME 'memberUid' EQUALITY caseExac
- tIA5Match SUBSTR caseExactIA5SubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.12
- 1.1.26 )
-olcAttributeTypes: {11}( 1.3.6.1.1.1.1.13 NAME 'memberNisNetgroup' EQUALITY
- caseExactIA5Match SUBSTR caseExactIA5SubstringsMatch SYNTAX 1.3.6.1.4.1.146
- 6.115.121.1.26 )
+ tMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+olcAttributeTypes: {11}( 1.3.6.1.1.1.1.13 NAME 'memberNisNetgroup' EQUALITY 
+ caseExactMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
 olcAttributeTypes: {12}( 1.3.6.1.1.1.1.14 NAME 'nisNetgroupTriple' DESC 'Net
- group triple' SYNTAX 1.3.6.1.1.1.0.0 )
-olcAttributeTypes: {13}( 1.3.6.1.1.1.1.15 NAME 'ipServicePort' EQUALITY inte
- gerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
-olcAttributeTypes: {14}( 1.3.6.1.1.1.1.16 NAME 'ipServiceProtocol' SUP name
- )
-olcAttributeTypes: {15}( 1.3.6.1.1.1.1.17 NAME 'ipProtocolNumber' EQUALITY i
- ntegerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
-olcAttributeTypes: {16}( 1.3.6.1.1.1.1.18 NAME 'oncRpcNumber' EQUALITY integ
- erMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
-olcAttributeTypes: {17}( 1.3.6.1.1.1.1.19 NAME 'ipHostNumber' DESC 'IP addre
- ss' EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{128} )
+ group triple' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYN
+ TAX 1.3.6.1.4.1.1466.115.121.1.15 )
+olcAttributeTypes: {13}( 1.3.6.1.1.1.1.15 NAME 'ipServicePort' DESC 'Service
+  port number' EQUALITY integerMatch ORDERING integerOrderingMatch SYNTAX 1.
+ 3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {14}( 1.3.6.1.1.1.1.16 NAME 'ipServiceProtocol' DESC 'Ser
+ vice protocol name' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.12
+ 1.1.15 )
+olcAttributeTypes: {15}( 1.3.6.1.1.1.1.17 NAME 'ipProtocolNumber' DESC 'IP p
+ rotocol number' EQUALITY integerMatch ORDERING integerOrderingMatch SYNTAX 
+ 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {16}( 1.3.6.1.1.1.1.18 NAME 'oncRpcNumber' DESC 'ONC RPC 
+ number' EQUALITY integerMatch ORDERING integerOrderingMatch SYNTAX 1.3.6.1.
+ 4.1.1466.115.121.1.27 SINGLE-VALUE )
+olcAttributeTypes: {17}( 1.3.6.1.1.1.1.19 NAME 'ipHostNumber' DESC 'IPv4 add
+ resses as a dotted decimal omitting leading               zeros or IPv6 add
+ resses as defined in RFC2373' EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4.
+ 1.1466.115.121.1.26 )
 olcAttributeTypes: {18}( 1.3.6.1.1.1.1.20 NAME 'ipNetworkNumber' DESC 'IP ne
- twork' EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{128
- } SINGLE-VALUE )
+ twork omitting leading zeros, eg. 192.168' EQUALITY caseIgnoreIA5Match SYNT
+ AX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE )
 olcAttributeTypes: {19}( 1.3.6.1.1.1.1.21 NAME 'ipNetmaskNumber' DESC 'IP ne
- tmask' EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{128
- } SINGLE-VALUE )
+ tmask omitting leading zeros, eg. 255.255.255.0' EQUALITY caseIgnoreIA5Matc
+ h SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE )
 olcAttributeTypes: {20}( 1.3.6.1.1.1.1.22 NAME 'macAddress' DESC 'MAC addres
- s' EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{128} )
+ s in maximal, colon separated hex               notation, eg. 00:00:92:90:e
+ e:e2' EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
 olcAttributeTypes: {21}( 1.3.6.1.1.1.1.23 NAME 'bootParameter' DESC 'rpc.boo
- tparamd parameter' SYNTAX 1.3.6.1.1.1.0.1 )
+ tparamd parameter' EQUALITY caseExactIA5Match SYNTAX 1.3.6.1.4.1.1466.115.1
+ 21.1.26 )
 olcAttributeTypes: {22}( 1.3.6.1.1.1.1.24 NAME 'bootFile' DESC 'Boot image n
  ame' EQUALITY caseExactIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
-olcAttributeTypes: {23}( 1.3.6.1.1.1.1.26 NAME 'nisMapName' SUP name )
-olcAttributeTypes: {24}( 1.3.6.1.1.1.1.27 NAME 'nisMapEntry' EQUALITY caseEx
- actIA5Match SUBSTR caseExactIA5SubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.
- 121.1.26{1024} SINGLE-VALUE )
+olcAttributeTypes: {23}( 1.3.6.1.1.1.1.26 NAME 'nisMapName' DESC 'Name of a 
+ generic NIS map' EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1
+ .15{64} )
+olcAttributeTypes: {24}( 1.3.6.1.1.1.1.27 NAME 'nisMapEntry' DESC 'A generic
+  NIS entry' EQUALITY caseExactMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{10
+ 24} SINGLE-VALUE )
+olcAttributeTypes: {25}( 1.3.6.1.1.1.1.28 NAME 'nisPublicKey' DESC 'NIS publ
+ ic key' EQUALITY octetStringMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 SING
+ LE-VALUE )
+olcAttributeTypes: {26}( 1.3.6.1.1.1.1.29 NAME 'nisSecretKey' DESC 'NIS secr
+ et key' EQUALITY octetStringMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 SING
+ LE-VALUE )
+olcAttributeTypes: {27}( 1.3.6.1.1.1.1.30 NAME 'nisDomain' DESC 'NIS domain'
+  EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{256} )
+olcAttributeTypes: {28}( 1.3.6.1.1.1.1.31 NAME 'automountMapName' DESC 'auto
+ mount Map Name' EQUALITY caseExactMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.1
+ 5 SINGLE-VALUE )
+olcAttributeTypes: {29}( 1.3.6.1.1.1.1.32 NAME 'automountKey' DESC 'Automoun
+ t Key value' EQUALITY caseExactMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 S
+ INGLE-VALUE )
+olcAttributeTypes: {30}( 1.3.6.1.1.1.1.33 NAME 'automountInformation' DESC '
+ Automount information' EQUALITY caseExactMatch SYNTAX 1.3.6.1.4.1.1466.115.
+ 121.1.15 SINGLE-VALUE )
 olcObjectClasses: {0}( 1.3.6.1.1.1.2.0 NAME 'posixAccount' DESC 'Abstraction
   of an account with POSIX attributes' SUP top AUXILIARY MUST ( cn $ uid $ u
  idNumber $ gidNumber $ homeDirectory ) MAY ( userPassword $ loginShell $ ge
  cos $ description ) )
 olcObjectClasses: {1}( 1.3.6.1.1.1.2.1 NAME 'shadowAccount' DESC 'Additional
   attributes for shadow passwords' SUP top AUXILIARY MUST uid MAY ( userPass
- word $ shadowLastChange $ shadowMin $ shadowMax $ shadowWarning $ shadowIna
- ctive $ shadowExpire $ shadowFlag $ description ) )
+ word $ description $ shadowLastChange $ shadowMin $ shadowMax $ shadowWarni
+ ng $ shadowInactive $ shadowExpire $ shadowFlag ) )
 olcObjectClasses: {2}( 1.3.6.1.1.1.2.2 NAME 'posixGroup' DESC 'Abstraction o
- f a group of accounts' SUP top STRUCTURAL MUST ( cn $ gidNumber ) MAY ( use
- rPassword $ memberUid $ description ) )
+ f a group of accounts' SUP top AUXILIARY MUST gidNumber MAY ( userPassword 
+ $ memberUid $ description ) )
 olcObjectClasses: {3}( 1.3.6.1.1.1.2.3 NAME 'ipService' DESC 'Abstraction an
-  Internet Protocol service' SUP top STRUCTURAL MUST ( cn $ ipServicePort $
- ipServiceProtocol ) MAY description )
+  Internet Protocol service.               Maps an IP port and protocol (suc
+ h as tcp or udp)               to one or more names; the distinguished valu
+ e of               the cn attribute denotes the services canonical         
+       name' SUP top STRUCTURAL MUST ( cn $ ipServicePort $ ipServiceProtoco
+ l ) MAY description )
 olcObjectClasses: {4}( 1.3.6.1.1.1.2.4 NAME 'ipProtocol' DESC 'Abstraction o
- f an IP protocol' SUP top STRUCTURAL MUST ( cn $ ipProtocolNumber $ descrip
- tion ) MAY description )
+ f an IP protocol. Maps a protocol number               to one or more names
+ . The distinguished value of the cn               attribute denotes the pro
+ tocol canonical name' SUP top STRUCTURAL MUST ( cn $ ipProtocolNumber ) MAY
+  description )
 olcObjectClasses: {5}( 1.3.6.1.1.1.2.5 NAME 'oncRpc' DESC 'Abstraction of an
-  ONC/RPC binding' SUP top STRUCTURAL MUST ( cn $ oncRpcNumber $ description
-  ) MAY description )
-olcObjectClasses: {6}( 1.3.6.1.1.1.2.6 NAME 'ipHost' DESC 'Abstraction of a
- host, an IP device' SUP top AUXILIARY MUST ( cn $ ipHostNumber ) MAY ( l $
- description $ manager ) )
+  Open Network Computing (ONC)              [RFC1057] Remote Procedure Call 
+ (RPC) binding.              This class maps an ONC RPC number to a name.   
+            The distinguished value of the cn attribute denotes             
+  the RPC service canonical name' SUP top STRUCTURAL MUST ( cn $ oncRpcNumbe
+ r ) MAY description )
+olcObjectClasses: {6}( 1.3.6.1.1.1.2.6 NAME 'ipHost' DESC 'Abstraction of a 
+ host, an IP device. The distinguished               value of the cn attribu
+ te denotes the hosts canonical            name. Device SHOULD be used as a 
+ structural class' SUP top AUXILIARY MUST ( cn $ ipHostNumber ) MAY ( userPa
+ ssword $ l $ description $ manager ) )
 olcObjectClasses: {7}( 1.3.6.1.1.1.2.7 NAME 'ipNetwork' DESC 'Abstraction of
-  an IP network' SUP top STRUCTURAL MUST ( cn $ ipNetworkNumber ) MAY ( ipNe
- tmaskNumber $ l $ description $ manager ) )
-olcObjectClasses: {8}( 1.3.6.1.1.1.2.8 NAME 'nisNetgroup' DESC 'Abstraction
- of a netgroup' SUP top STRUCTURAL MUST cn MAY ( nisNetgroupTriple $ memberN
- isNetgroup $ description ) )
+  a network. The distinguished value of               the cn attribute denot
+ es the network canonical name' SUP top STRUCTURAL MUST ipNetworkNumber MAY 
+ ( cn $ ipNetmaskNumber $ l $ description $ manager ) )
+olcObjectClasses: {8}( 1.3.6.1.1.1.2.8 NAME 'nisNetgroup' DESC 'Abstraction 
+ of a netgroup. May refer to other               netgroups' SUP top STRUCTUR
+ AL MUST cn MAY ( nisNetgroupTriple $ memberNisNetgroup $ description ) )
 olcObjectClasses: {9}( 1.3.6.1.1.1.2.9 NAME 'nisMap' DESC 'A generic abstrac
  tion of a NIS map' SUP top STRUCTURAL MUST nisMapName MAY description )
-olcObjectClasses: {10}( 1.3.6.1.1.1.2.10 NAME 'nisObject' DESC 'An entry in
- a NIS map' SUP top STRUCTURAL MUST ( cn $ nisMapEntry $ nisMapName ) MAY de
- scription )
+olcObjectClasses: {10}( 1.3.6.1.1.1.2.10 NAME 'nisObject' DESC 'An entry in 
+ a NIS map' SUP top STRUCTURAL MUST ( cn $ nisMapEntry $ nisMapName ) )
 olcObjectClasses: {11}( 1.3.6.1.1.1.2.11 NAME 'ieee802Device' DESC 'A device
-  with a MAC address' SUP top AUXILIARY MAY macAddress )
+  with a MAC address; device SHOULD be               used as a structural cl
+ ass' SUP top AUXILIARY MAY macAddress )
 olcObjectClasses: {12}( 1.3.6.1.1.1.2.12 NAME 'bootableDevice' DESC 'A devic
- e with boot parameters' SUP top AUXILIARY MAY ( bootFile $ bootParameter )
- )
-structuralObjectClass: olcSchemaConfig
-entryUUID: 380c8b3e-3cda-1035-96b4-afdc2ea1e219
-creatorsName: cn=admin,cn=config
-createTimestamp: 20151222092918Z
-entryCSN: 20151222092918.154799Z#000000#000#000000
-modifiersName: cn=admin,cn=config
-modifyTimestamp: 20151222092918Z
-
+ e with boot parameters; device SHOULD be               used as a structural
+  class' SUP top AUXILIARY MAY ( bootFile $ bootParameter ) )
+olcObjectClasses: {13}( 1.3.6.1.1.1.2.14 NAME 'nisKeyObject' DESC 'An object
+  with a public and secret key' SUP top AUXILIARY MUST ( cn $ nisPublicKey $
+  nisSecretKey ) MAY ( uidNumber $ description ) )
+olcObjectClasses: {14}( 1.3.6.1.1.1.2.15 NAME 'nisDomainObject' DESC 'Associ
+ ates a NIS domain with a naming context' SUP top AUXILIARY MUST nisDomain )
+olcObjectClasses: {15}( 1.3.6.1.1.1.2.16 NAME 'automountMap' SUP top STRUCTU
+ RAL MUST automountMapName MAY description )
+olcObjectClasses: {16}( 1.3.6.1.1.1.2.17 NAME 'automount' DESC 'Automount in
+ formation' SUP top STRUCTURAL MUST ( automountKey $ automountInformation ) 
+ MAY description )
+olcObjectClasses: {17}( 1.3.6.1.1.1.2.18 NAME 'groupOfMembers' DESC 'A group
+  with members (DNs)' SUP top STRUCTURAL MUST cn MAY ( businessCategory $ se
+ eAlso $ owner $ ou $ o $ description $ member ) )

--- a/openldap/rfc2307bis/rfc2307bis.schema
+++ b/openldap/rfc2307bis/rfc2307bis.schema
@@ -1,283 +1,385 @@
-#attributetype ( 1.3.6.1.1.1.1.0 NAME 'uidNumber'
-#  DESC 'An integer uniquely identifying a user in an administrative domain'
-#  EQUALITY integerMatch
-#  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-#  SINGLE-VALUE )
+#
+# rfc2307bis.schema
+#
+# Extracted from http://tools.ietf.org/id/draft-howard-rfc2307bis-02.txt
+# as of 2012/05/25, by Robin H. Johnson <robbat2@gentoo.org>
+# Found at http://dev.gentoo.org/~robbat2/distfiles/rfc2307bis.schema-20120525
+#
+# Changed so that OpenLDAP 2.4.39 is able to import the schema
+# on 2014/11/28 by Stijn Hoop <stijn@sandcat.nl>
+#
+#attributetype     ( 1.3.6.1.1.1.1.0 NAME 'uidNumber'
+#         DESC 'An integer uniquely identifying a user in an
+#               administrative domain'
+#         EQUALITY integerMatch
+#         ORDERING integerOrderingMatch
+#         SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+#         SINGLE-VALUE )
+#
+#
+#attributetype     ( 1.3.6.1.1.1.1.1 NAME 'gidNumber'
+#         DESC 'An integer uniquely identifying a group in an
+#               administrative domain'
+#         EQUALITY integerMatch
+#         ORDERING integerOrderingMatch
+#         SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+#         SINGLE-VALUE )
 
-#attributetype ( 1.3.6.1.1.1.1.1 NAME 'gidNumber'
-#  DESC 'An integer uniquely identifying a group in an
-#        administrative domain'
-#  EQUALITY integerMatch
-#  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-#  SINGLE-VALUE )
 
-attributetype ( 1.3.6.1.1.1.1.2 NAME 'gecos'
-  DESC 'The GECOS field; the common name'
-  EQUALITY caseIgnoreIA5Match
-  SUBSTR caseIgnoreIA5SubstringsMatch
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
-  SINGLE-VALUE )
+attributetype     ( 1.3.6.1.1.1.1.2 NAME 'gecos'
+         DESC 'The GECOS field; the common name'
+         EQUALITY caseIgnoreMatch
+         SUBSTR caseIgnoreSubstringsMatch
+         SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+         SINGLE-VALUE )
 
-attributetype ( 1.3.6.1.1.1.1.3 NAME 'homeDirectory'
-  DESC 'The absolute path to the home directory'
-  EQUALITY caseExactIA5Match
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
-  SINGLE-VALUE )
 
-attributetype ( 1.3.6.1.1.1.1.4 NAME 'loginShell'
-  DESC 'The path to the login shell'
-  EQUALITY caseExactIA5Match
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
-  SINGLE-VALUE )
+attributetype     ( 1.3.6.1.1.1.1.3 NAME 'homeDirectory'
+         DESC 'The absolute path to the home directory'
+         EQUALITY caseExactIA5Match
+         SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+         SINGLE-VALUE )
 
-attributetype ( 1.3.6.1.1.1.1.5 NAME 'shadowLastChange'
-  EQUALITY integerMatch
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-  SINGLE-VALUE )
 
-attributetype ( 1.3.6.1.1.1.1.6 NAME 'shadowMin'
-  EQUALITY integerMatch
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-  SINGLE-VALUE )
+attributetype     ( 1.3.6.1.1.1.1.4 NAME 'loginShell'
+         DESC 'The path to the login shell'
+         EQUALITY caseExactIA5Match
+         SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+         SINGLE-VALUE )
+     
+attributetype     ( 1.3.6.1.1.1.1.5 NAME 'shadowLastChange'
+         EQUALITY integerMatch
+         ORDERING integerOrderingMatch
+         SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+         SINGLE-VALUE )
 
-attributetype ( 1.3.6.1.1.1.1.7 NAME 'shadowMax'
-  EQUALITY integerMatch
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-  SINGLE-VALUE )
 
-attributetype ( 1.3.6.1.1.1.1.8 NAME 'shadowWarning'
-  EQUALITY integerMatch
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-  SINGLE-VALUE )
+attributetype     ( 1.3.6.1.1.1.1.6 NAME 'shadowMin'
+         EQUALITY integerMatch
+         ORDERING integerOrderingMatch
+         SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+         SINGLE-VALUE )
 
-attributetype ( 1.3.6.1.1.1.1.9 NAME 'shadowInactive'
-  EQUALITY integerMatch
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-  SINGLE-VALUE )
 
-attributetype ( 1.3.6.1.1.1.1.10 NAME 'shadowExpire'
-  EQUALITY integerMatch
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-  SINGLE-VALUE )
+attributetype     ( 1.3.6.1.1.1.1.7 NAME 'shadowMax'
+         EQUALITY integerMatch
+         ORDERING integerOrderingMatch
+         SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+         SINGLE-VALUE )
 
-attributetype ( 1.3.6.1.1.1.1.11 NAME 'shadowFlag'
-  EQUALITY integerMatch
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-  SINGLE-VALUE )
 
-attributetype ( 1.3.6.1.1.1.1.12 NAME 'memberUid'
-  EQUALITY caseExactIA5Match
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+attributetype     ( 1.3.6.1.1.1.1.8 NAME 'shadowWarning'
+         EQUALITY integerMatch
+         ORDERING integerOrderingMatch
+         SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+         SINGLE-VALUE )
 
-attributetype ( 1.3.6.1.1.1.1.13 NAME 'memberNisNetgroup'
-  EQUALITY caseExactIA5Match
-  SUBSTR caseExactIA5SubstringsMatch
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
 
-attributetype ( 1.3.6.1.1.1.1.14 NAME 'nisNetgroupTriple'
-  DESC 'Netgroup triple'
-  EQUALITY caseIgnoreIA5Match
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+attributetype     ( 1.3.6.1.1.1.1.9 NAME 'shadowInactive'
+         EQUALITY integerMatch
+         ORDERING integerOrderingMatch
+         SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+         SINGLE-VALUE )
 
-attributetype ( 1.3.6.1.1.1.1.15 NAME 'ipServicePort'
-  DESC 'Service port number'
-  EQUALITY integerMatch
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-  SINGLE-VALUE )
 
-attributetype ( 1.3.6.1.1.1.1.16 NAME 'ipServiceProtocol'
-  DESC 'Service protocol name'
-  SUP name )
+attributetype     ( 1.3.6.1.1.1.1.10 NAME 'shadowExpire'
+         EQUALITY integerMatch
+         ORDERING integerOrderingMatch
+         SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+         SINGLE-VALUE )
 
-attributetype ( 1.3.6.1.1.1.1.17 NAME 'ipProtocolNumber'
-  DESC 'IP protocol number'
-  EQUALITY integerMatch
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-  SINGLE-VALUE )
 
-attributetype ( 1.3.6.1.1.1.1.18 NAME 'oncRpcNumber'
-  DESC 'ONC RPC number'
-  EQUALITY integerMatch
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-  SINGLE-VALUE )
-attributetype ( 1.3.6.1.1.1.1.19 NAME 'ipHostNumber'
-  DESC 'IPv4 addresses as a dotted decimal omitting leading
-        zeros or IPv6 addresses as defined in RFC2373'
-  SUP name )
+attributetype     ( 1.3.6.1.1.1.1.11 NAME 'shadowFlag'
+         EQUALITY integerMatch
+         ORDERING integerOrderingMatch
+         SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+         SINGLE-VALUE )
 
-attributetype ( 1.3.6.1.1.1.1.20 NAME 'ipNetworkNumber'
-  DESC 'IP network as a dotted decimal, eg. 192.168,
-        omitting leading zeros'
-  SUP name
-  SINGLE-VALUE )
 
-attributetype ( 1.3.6.1.1.1.1.21 NAME 'ipNetmaskNumber'
-  DESC 'IP netmask as a dotted decimal, eg. 255.255.255.0,
-        omitting leading zeros'
-  EQUALITY caseIgnoreIA5Match
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
-  SINGLE-VALUE )
 
-attributetype ( 1.3.6.1.1.1.1.22 NAME 'macAddress'
-  DESC 'MAC address in maximal, colon separated hex
-        notation, eg. 00:00:92:90:ee:e2'
-  EQUALITY caseIgnoreIA5Match
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
 
-attributetype ( 1.3.6.1.1.1.1.23 NAME 'bootParameter'
-  DESC 'rpc.bootparamd parameter'
-  EQUALITY caseExactIA5Match
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+attributetype     ( 1.3.6.1.1.1.1.12 NAME 'memberUid'
+         EQUALITY caseExactMatch
+         SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
 
-attributetype ( 1.3.6.1.1.1.1.24 NAME 'bootFile'
-  DESC 'Boot image name'
-  EQUALITY caseExactIA5Match
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
 
-attributetype ( 1.3.6.1.1.1.1.26 NAME 'nisMapName'
-  DESC 'Name of a A generic NIS map'
-  SUP name )
+attributetype     ( 1.3.6.1.1.1.1.13 NAME 'memberNisNetgroup'
+         EQUALITY caseExactMatch
+         SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
 
-attributetype ( 1.3.6.1.1.1.1.27 NAME 'nisMapEntry'
-  DESC 'A generic NIS entry'
-  EQUALITY caseExactIA5Match
-  SUBSTR caseExactIA5SubstringsMatch
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
-  SINGLE-VALUE )
 
-attributetype ( 1.3.6.1.1.1.1.28 NAME 'nisPublicKey'
-  DESC 'NIS public key'
-  EQUALITY octetStringMatch
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 SINGLE-VALUE )
+attributetype     ( 1.3.6.1.1.1.1.14 NAME 'nisNetgroupTriple'
+         DESC 'Netgroup triple'
+         EQUALITY caseIgnoreMatch
+         SUBSTR caseIgnoreSubstringsMatch
+         SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
 
-attributetype ( 1.3.6.1.1.1.1.29 NAME 'nisSecretKey'
-  DESC 'NIS secret key'
-  EQUALITY octetStringMatch
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 SINGLE-VALUE )
 
-attributetype ( 1.3.6.1.1.1.1.30 NAME 'nisDomain'
-  DESC 'NIS domain'
-  EQUALITY caseIgnoreIA5Match
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26)
+attributetype     ( 1.3.6.1.1.1.1.15 NAME 'ipServicePort'
+         DESC 'Service port number'
+         EQUALITY integerMatch
+         ORDERING integerOrderingMatch
+         SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+         SINGLE-VALUE )
 
-attributetype ( 1.3.6.1.1.1.1.31 NAME 'automountMapName'
-  DESC 'automount Map Name'
-  EQUALITY caseExactIA5Match
-  SUBSTR caseExactIA5SubstringsMatch
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE )
 
-attributetype ( 1.3.6.1.1.1.1.32 NAME 'automountKey'
-  DESC 'Automount Key value'
-  EQUALITY caseExactIA5Match
-  SUBSTR caseExactIA5SubstringsMatch
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE )
+attributetype     ( 1.3.6.1.1.1.1.16 NAME 'ipServiceProtocol'
+         DESC 'Service protocol name'
+         EQUALITY caseIgnoreMatch
+         SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
 
-attributetype ( 1.3.6.1.1.1.1.33 NAME 'automountInformation'
-  DESC 'Automount information'
-  EQUALITY caseExactIA5Match
-  SUBSTR caseExactIA5SubstringsMatch
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE )
 
-objectclass ( 1.3.6.1.1.1.2.0 NAME 'posixAccount' SUP top AUXILIARY
-  DESC 'Abstraction of an account with POSIX attributes'
-  MUST ( cn $ uid $ uidNumber $ gidNumber $ homeDirectory )
-  MAY ( userPassword $ loginShell $ gecos $
-        description ) )
+attributetype     ( 1.3.6.1.1.1.1.17 NAME 'ipProtocolNumber'
+         DESC 'IP protocol number'
+         EQUALITY integerMatch
+         ORDERING integerOrderingMatch
+         SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+         SINGLE-VALUE )
 
-objectclass ( 1.3.6.1.1.1.2.1 NAME 'shadowAccount' SUP top AUXILIARY
-  DESC 'Additional attributes for shadow passwords'
-  MUST uid
-  MAY ( userPassword $ description $
-        shadowLastChange $ shadowMin $ shadowMax $
-        shadowWarning $ shadowInactive $
-        shadowExpire $ shadowFlag ) )
 
-objectclass ( 1.3.6.1.1.1.2.2 NAME 'posixGroup' SUP top AUXILIARY
-  DESC 'Abstraction of a group of accounts'
-  MUST gidNumber
-  MAY ( userPassword $ memberUid $
-        description ) )
+attributetype     ( 1.3.6.1.1.1.1.18 NAME 'oncRpcNumber'
+         DESC 'ONC RPC number'
+         EQUALITY integerMatch
+         ORDERING integerOrderingMatch
+         SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+         SINGLE-VALUE )
 
-objectclass ( 1.3.6.1.1.1.2.3 NAME 'ipService' SUP top STRUCTURAL
-  DESC 'Abstraction an Internet Protocol service.
-        Maps an IP port and protocol (such as tcp or udp)
-        to one or more names; the distinguished value of
-        the cn attribute denotes the services canonical
-        name'
-  MUST ( cn $ ipServicePort $ ipServiceProtocol )
-  MAY description )
 
-objectclass ( 1.3.6.1.1.1.2.4 NAME 'ipProtocol' SUP top STRUCTURAL
-  DESC 'Abstraction of an IP protocol. Maps a protocol number
-        to one or more names. The distinguished value of the cn
-        attribute denotes the protocols canonical name'
-  MUST ( cn $ ipProtocolNumber )
-  MAY description )
 
-objectclass ( 1.3.6.1.1.1.2.5 NAME 'oncRpc' SUP top STRUCTURAL
-  DESC 'Abstraction of an Open Network Computing (ONC)
-       [RFC1057] Remote Procedure Call (RPC) binding.
-       This class maps an ONC RPC number to a name.
-       The distinguished value of the cn attribute denotes
-       the RPC services canonical name'
-  MUST ( cn $ oncRpcNumber )
-  MAY description )
 
-objectclass ( 1.3.6.1.1.1.2.6 NAME 'ipHost' SUP top AUXILIARY
-  DESC 'Abstraction of a host, an IP device. The distinguished
-        value of the cn attribute denotes the hosts canonical
-        name. Device SHOULD be used as a structural class'
-  MUST ( cn $ ipHostNumber )
-  MAY ( userPassword $ l $ description $ manager ) )
 
-objectclass ( 1.3.6.1.1.1.2.7 NAME 'ipNetwork' SUP top STRUCTURAL
-  DESC 'Abstraction of a network. The distinguished value of
-        the cn attribute denotes the networks canonical name'
-  MUST ipNetworkNumber
-  MAY ( cn $ ipNetmaskNumber $ l $ description $ manager ) )
 
-objectclass ( 1.3.6.1.1.1.2.8 NAME 'nisNetgroup' SUP top STRUCTURAL
-  DESC 'Abstraction of a netgroup. May refer to other netgroups'
-  MUST cn
-  MAY ( nisNetgroupTriple $ memberNisNetgroup $ description ) )
 
-objectclass ( 1.3.6.1.1.1.2.9 NAME 'nisMap' SUP top STRUCTURAL
-  DESC 'A generic abstraction of a NIS map'
-  MUST nisMapName
-  MAY description )
 
-objectclass ( 1.3.6.1.1.1.2.10 NAME 'nisObject' SUP top STRUCTURAL
-  DESC 'An entry in a NIS map'
-  MUST ( cn $ nisMapEntry $ nisMapName )
-  MAY description )
+attributetype     ( 1.3.6.1.1.1.1.19 NAME 'ipHostNumber'
+         DESC 'IPv4 addresses as a dotted decimal omitting leading
+               zeros or IPv6 addresses as defined in RFC2373'
+         EQUALITY caseIgnoreIA5Match
+         SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
 
-objectclass ( 1.3.6.1.1.1.2.11 NAME 'ieee802Device' SUP top AUXILIARY
-  DESC 'A device with a MAC address; device SHOULD be
-        used as a structural class'
-  MAY macAddress )
 
-objectclass ( 1.3.6.1.1.1.2.12 NAME 'bootableDevice' SUP top AUXILIARY
-  DESC 'A device with boot parameters; device SHOULD be
-        used as a structural class'
-  MAY ( bootFile $ bootParameter ) )
+attributetype     ( 1.3.6.1.1.1.1.20 NAME 'ipNetworkNumber'
+         DESC 'IP network omitting leading zeros, eg. 192.168'
+         EQUALITY caseIgnoreIA5Match
+         SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+         SINGLE-VALUE )
 
-objectclass ( 1.3.6.1.1.1.2.14 NAME 'nisKeyObject' SUP top AUXILIARY
-  DESC 'An object with a public and secret key'
-  MUST ( cn $ nisPublicKey $ nisSecretKey )
-  MAY ( uidNumber $ description ) )
 
-objectclass ( 1.3.6.1.1.1.2.15 NAME 'nisDomainObject' SUP top AUXILIARY
-  DESC 'Associates a NIS domain with a naming context'
-  MUST nisDomain )
+attributetype     ( 1.3.6.1.1.1.1.21 NAME 'ipNetmaskNumber'
+         DESC 'IP netmask omitting leading zeros, eg. 255.255.255.0'
+         EQUALITY caseIgnoreIA5Match
+         SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+         SINGLE-VALUE )
 
-objectclass ( 1.3.6.1.1.1.2.16 NAME 'automountMap' SUP top STRUCTURAL
-  MUST ( automountMapName )
-  MAY description )
 
-objectclass ( 1.3.6.1.1.1.2.17 NAME 'automount' SUP top STRUCTURAL
-  DESC 'Automount information'
-  MUST ( automountKey $ automountInformation )
-  MAY description )
-## namedObject is needed for groups without members
-objectclass ( 1.3.6.1.4.1.5322.13.1.1 NAME 'namedObject' SUP top
-       STRUCTURAL MAY cn )
+attributetype     ( 1.3.6.1.1.1.1.22 NAME 'macAddress'
+         DESC 'MAC address in maximal, colon separated hex
+               notation, eg. 00:00:92:90:ee:e2'
+         EQUALITY caseIgnoreIA5Match
+         SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+
+attributetype     ( 1.3.6.1.1.1.1.23 NAME 'bootParameter'
+         DESC 'rpc.bootparamd parameter'
+         EQUALITY caseExactIA5Match
+         SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+
+attributetype     ( 1.3.6.1.1.1.1.24 NAME 'bootFile'
+         DESC 'Boot image name'
+         EQUALITY caseExactIA5Match
+         SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+
+
+attributetype     ( 1.3.6.1.1.1.1.26 NAME 'nisMapName'
+         DESC 'Name of a generic NIS map'
+         EQUALITY caseIgnoreMatch
+         SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{64} )
+
+
+
+
+
+
+
+
+
+attributetype     ( 1.3.6.1.1.1.1.27 NAME 'nisMapEntry'
+         DESC 'A generic NIS entry'
+         EQUALITY caseExactMatch
+         SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{1024}
+         SINGLE-VALUE )
+
+
+attributetype     ( 1.3.6.1.1.1.1.28 NAME 'nisPublicKey'
+         DESC 'NIS public key'
+         EQUALITY octetStringMatch
+         SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+         SINGLE-VALUE )
+
+
+attributetype     ( 1.3.6.1.1.1.1.29 NAME 'nisSecretKey'
+         DESC 'NIS secret key'
+         EQUALITY octetStringMatch
+         SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+         SINGLE-VALUE )
+
+
+attributetype     ( 1.3.6.1.1.1.1.30 NAME 'nisDomain'
+         DESC 'NIS domain'
+         EQUALITY caseIgnoreIA5Match
+         SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{256} )
+
+
+attributetype     ( 1.3.6.1.1.1.1.31 NAME 'automountMapName'
+         DESC 'automount Map Name'
+         EQUALITY caseExactMatch
+         SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+         SINGLE-VALUE )
+
+
+attributetype     ( 1.3.6.1.1.1.1.32 NAME 'automountKey'
+         DESC 'Automount Key value'
+         EQUALITY caseExactMatch
+         SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+         SINGLE-VALUE )
+
+
+attributetype     ( 1.3.6.1.1.1.1.33 NAME 'automountInformation'
+         DESC 'Automount information'
+         EQUALITY caseExactMatch
+         SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+         SINGLE-VALUE )
+
+
+
+objectclass     ( 1.3.6.1.1.1.2.0 NAME 'posixAccount' SUP top AUXILIARY
+         DESC 'Abstraction of an account with POSIX attributes'
+         MUST ( cn $ uid $ uidNumber $ gidNumber $ homeDirectory )
+         MAY ( userPassword $ loginShell $ gecos $
+               description ) )
+
+
+objectclass     ( 1.3.6.1.1.1.2.1 NAME 'shadowAccount' SUP top AUXILIARY
+         DESC 'Additional attributes for shadow passwords'
+         MUST uid
+         MAY ( userPassword $ description $
+               shadowLastChange $ shadowMin $ shadowMax $
+               shadowWarning $ shadowInactive $
+               shadowExpire $ shadowFlag ) )
+
+
+objectclass     ( 1.3.6.1.1.1.2.2 NAME 'posixGroup' SUP top AUXILIARY
+         DESC 'Abstraction of a group of accounts'
+         MUST gidNumber
+         MAY ( userPassword $ memberUid $
+               description ) )
+
+
+objectclass     ( 1.3.6.1.1.1.2.3 NAME 'ipService' SUP top STRUCTURAL
+         DESC 'Abstraction an Internet Protocol service.
+               Maps an IP port and protocol (such as tcp or udp)
+               to one or more names; the distinguished value of
+               the cn attribute denotes the services canonical
+               name'
+         MUST ( cn $ ipServicePort $ ipServiceProtocol )
+         MAY description )
+
+
+objectclass     ( 1.3.6.1.1.1.2.4 NAME 'ipProtocol' SUP top STRUCTURAL
+         DESC 'Abstraction of an IP protocol. Maps a protocol number
+               to one or more names. The distinguished value of the cn
+               attribute denotes the protocol canonical name'
+         MUST ( cn $ ipProtocolNumber )
+         MAY description )
+
+
+
+
+
+objectclass     ( 1.3.6.1.1.1.2.5 NAME 'oncRpc' SUP top STRUCTURAL
+         DESC 'Abstraction of an Open Network Computing (ONC)
+              [RFC1057] Remote Procedure Call (RPC) binding.
+              This class maps an ONC RPC number to a name.
+              The distinguished value of the cn attribute denotes
+              the RPC service canonical name'
+         MUST ( cn $ oncRpcNumber )
+         MAY description )
+
+
+objectclass     ( 1.3.6.1.1.1.2.6 NAME 'ipHost' SUP top AUXILIARY
+         DESC 'Abstraction of a host, an IP device. The distinguished
+               value of the cn attribute denotes the hosts canonical
+            name. Device SHOULD be used as a structural class'
+         MUST ( cn $ ipHostNumber )
+         MAY ( userPassword $ l $ description $
+               manager ) )
+
+
+objectclass     ( 1.3.6.1.1.1.2.7 NAME 'ipNetwork' SUP top STRUCTURAL
+         DESC 'Abstraction of a network. The distinguished value of
+               the cn attribute denotes the network canonical name'
+         MUST ipNetworkNumber
+         MAY ( cn $ ipNetmaskNumber $ l $ description $ manager ) )
+
+
+objectclass     ( 1.3.6.1.1.1.2.8 NAME 'nisNetgroup' SUP top STRUCTURAL
+         DESC 'Abstraction of a netgroup. May refer to other
+               netgroups'
+         MUST cn
+         MAY ( nisNetgroupTriple $ memberNisNetgroup $ description ) )
+
+
+objectclass     ( 1.3.6.1.1.1.2.9 NAME 'nisMap' SUP top STRUCTURAL
+         DESC 'A generic abstraction of a NIS map'
+         MUST nisMapName
+         MAY description )
+
+
+objectclass     ( 1.3.6.1.1.1.2.10 NAME 'nisObject' SUP top STRUCTURAL
+         DESC 'An entry in a NIS map'
+         MUST ( cn $ nisMapEntry $ nisMapName ) )
+
+
+objectclass     ( 1.3.6.1.1.1.2.11 NAME 'ieee802Device' SUP top AUXILIARY
+         DESC 'A device with a MAC address; device SHOULD be
+               used as a structural class'
+         MAY macAddress )
+
+
+
+
+
+objectclass     ( 1.3.6.1.1.1.2.12 NAME 'bootableDevice' SUP top AUXILIARY
+         DESC 'A device with boot parameters; device SHOULD be
+               used as a structural class'
+         MAY ( bootFile $ bootParameter ) )
+
+
+objectclass     ( 1.3.6.1.1.1.2.14 NAME 'nisKeyObject' SUP top AUXILIARY
+         DESC 'An object with a public and secret key'
+         MUST ( cn $ nisPublicKey $ nisSecretKey )
+         MAY ( uidNumber $ description ) )
+
+
+objectclass     ( 1.3.6.1.1.1.2.15 NAME 'nisDomainObject' SUP top AUXILIARY
+         DESC 'Associates a NIS domain with a naming context'
+         MUST nisDomain )
+
+
+objectclass     ( 1.3.6.1.1.1.2.16 NAME 'automountMap' SUP top STRUCTURAL
+         MUST ( automountMapName )
+         MAY description )
+
+
+objectclass     ( 1.3.6.1.1.1.2.17 NAME 'automount' SUP top STRUCTURAL
+         DESC 'Automount information'
+         MUST ( automountKey $ automountInformation )
+         MAY description )
+
+
+objectclass     ( 1.3.6.1.1.1.2.18 NAME 'groupOfMembers' SUP top STRUCTURAL
+         DESC 'A group with members (DNs)'
+         MUST cn
+         MAY ( businessCategory $ seeAlso $ owner $ ou $ o $
+               description $ member ) )


### PR DESCRIPTION
The original rfc2307bis schema doesn't work. It was missing groupOfMembers among other constructions.