### PR TITLE
Mesos container updates.

### DIFF
--- a/mesos/Makefile
+++ b/mesos/Makefile
@@ -40,11 +40,17 @@ mesos: check-version
 	  sed -i -e "s/{UBUNTU_TESTING}//g" $@ ; \
 	fi
 	docker build -t mesosphere/$@:$(MESOS_TAG) - < $@
+	$(eval IMAGE_ID=$(shell docker images | grep 'mesosphere/$@ ' | grep $(MESOS_TAG) | awk '{print $$3}'))
+	docker tag $(IMAGE_ID) mesosphere/$@:latest
 
 mesos-master: mesos check-version
 	sed "s/{VERSION}/$(VERSION)/g" dockerfile-templates/$@ > $@
 	docker build -t mesosphere/$@:$(MESOS_TAG) - < $@
+	$(eval IMAGE_ID=$(shell docker images | grep 'mesosphere/$@' | grep $(MESOS_TAG) | awk '{print $$3}'))
+	docker tag $(shell docker images | grep "mesosphere/$@" | awk '{print $3}') mesosphere/$@:latest
 
 mesos-agent: mesos check-version
 	sed "s/{VERSION}/$(VERSION)/g" dockerfile-templates/$@ > $@
 	docker build -t mesosphere/$@:$(MESOS_TAG) - < $@
+	$(eval IMAGE_ID=$(shell docker images | grep 'mesosphere/$@' | grep $(MESOS_TAG) | awk '{print $$3}'))
+	docker tag $(shell docker images | grep "mesosphere/$@" | awk '{print $3}') mesosphere/$@:latest

--- a/mesos/Makefile
+++ b/mesos/Makefile
@@ -21,12 +21,12 @@ ifndef VERSION
 	@exit 1
 endif
 
-images: check-version mesos mesos-master mesos-slave
+images: check-version mesos mesos-master mesos-agent
 
 push: check-version
 	docker push mesosphere/mesos:$(MESOS_TAG)
 	docker push mesosphere/mesos-master:$(MESOS_TAG)
-	docker push mesosphere/mesos-slave:$(MESOS_TAG)
+	docker push mesosphere/mesos-agent:$(MESOS_TAG)
 
 mesos: check-version
 	echo $(VERSION)
@@ -45,6 +45,6 @@ mesos-master: mesos check-version
 	sed "s/{VERSION}/$(VERSION)/g" dockerfile-templates/$@ > $@
 	docker build -t mesosphere/$@:$(MESOS_TAG) - < $@
 
-mesos-slave: mesos check-version
+mesos-agent: mesos check-version
 	sed "s/{VERSION}/$(VERSION)/g" dockerfile-templates/$@ > $@
 	docker build -t mesosphere/$@:$(MESOS_TAG) - < $@

--- a/mesos/README.md
+++ b/mesos/README.md
@@ -10,7 +10,6 @@ Dockerfiles: https://github.com/mesosphere/docker-containers/tree/master/mesos
 
 Other Mesosphere Packages: https://mesosphere.com/downloads/
 
-
 ## Machines
 
 The recommended way to run Mesos in Docker is to run each master and slave container on their own machine, with their own IP.
@@ -19,6 +18,7 @@ The recommended way to run Mesos in Docker is to run each master and slave conta
 
 Host networking (`--net=host`) is recommended. While Mesos *can* operate in bridge networking, it is slower and has many caveats and configuration complexities.
 
+On Mac OSX, Mesos may be unable to perform a hostname lookup within the Docker container, in which case the master/agent will not launch. To fix this, specify `-e LIBPROCESS_ADVERTISE_IP=127.0.0.1` in the Docker command-line flags. This explicitly sets the IP that Mesos should advertise to other processes, eliminating the need for a hostname lookup.
 
 ## Example: Local Dev/Test
 

--- a/mesos/README.md
+++ b/mesos/README.md
@@ -59,6 +59,26 @@ docker run -d --net=host \
 
 [Slave Configuration Reference](https://open.mesosphere.com/reference/mesos-slave/)
 
+If the agent will make use of the Docker runtime, it can be configured in two different ways:
+* The agent can use its own Docker installation within the container, thus running Docker-in-Docker.
+* The host system's Docker installation can be mapped into the container so that the agent runs Docker containers on the host system. This will allow the agent's containers to continue running over agent failovers.
+
+To use the container's Docker installation:
+```
+docker run -d --net=host --privileged \
+  -e MESOS_PORT=5051 \
+  -e MESOS_MASTER=zk://127.0.0.1:2181/mesos \
+  -e MESOS_SWITCH_USER=0 \
+  -e MESOS_CONTAINERIZERS=docker,mesos \
+  -e MESOS_LOG_DIR=/var/log/mesos \
+  -e MESOS_WORK_DIR=/var/tmp/mesos \
+  -v "$(pwd)/log/mesos:/var/log/mesos" \
+  -v "$(pwd)/tmp/mesos:/var/tmp/mesos" \
+  --entrypoint /bin/bash \
+  mesosphere/mesos-slave:0.28.0-2.0.16.ubuntu1404 -c "sudo service docker start; mesos-agent"
+```
+
+To use the host system's Docker installation:
 ```
 docker run -d --net=host --privileged \
   -e MESOS_PORT=5051 \

--- a/mesos/README.md
+++ b/mesos/README.md
@@ -2,9 +2,9 @@
 
 [Mesosphere](https://mesosphere.com/) builds [Apache Mesos](http://mesos.apache.org/) into several [Docker](https://www.docker.com/) containers:
 
-- [mesosphere/mesos](https://hub.docker.com/r/mesosphere/mesos/) - Both the master and slave in the same container. Requires a custom command to run.
+- [mesosphere/mesos](https://hub.docker.com/r/mesosphere/mesos/) - Both the master and agent in the same container. Requires a custom command to run.
 - [mesosphere/mesos-master](https://hub.docker.com/r/mesosphere/mesos-master/) - Mesos-Master only
-- [mesosphere/mesos-slave](https://hub.docker.com/r/mesosphere/mesos-slave/) - Mesos-Slave only
+- [mesosphere/mesos-agent](https://hub.docker.com/r/mesosphere/mesos-agent/) - Mesos-Agent only
 
 Dockerfiles: https://github.com/mesosphere/docker-containers/tree/master/mesos
 
@@ -12,7 +12,7 @@ Other Mesosphere Packages: https://mesosphere.com/downloads/
 
 ## Machines
 
-The recommended way to run Mesos in Docker is to run each master and slave container on their own machine, with their own IP.
+The recommended way to run Mesos in Docker is to run each master and agent container on their own machine, with their own IP.
 
 ## Networking
 
@@ -22,13 +22,13 @@ On Mac OSX, Mesos may be unable to perform a hostname lookup within the Docker c
 
 ## Example: Local Dev/Test
 
-For development or experimentation, one Master and one Slave can be run on the same machine.
+For development or experimentation, one Master and one Agent can be run on the same machine.
 
-The following commands set up a local development environment with Exhibitor/Zookeeper, Mesos-Master, and Mesos-Slave, using host networking. This is not fit for production.
+The following commands set up a local development environment with Exhibitor/Zookeeper, Mesos-Master, and Mesos-Agent, using host networking. This is not fit for production.
 
 Caveats:
-- Docker containers launched by the Mesos-Slave will continue running on the host after the Mesos-Slave container has been stopped.
-- Docker volumes created by the Mesos-Slave will be relative to the host, not the Mesos-Slave container.
+- Docker containers launched by the Mesos-Agent will continue running on the host after the Mesos-Agent container has been stopped.
+- Docker volumes created by the Mesos-Agent will be relative to the host, not the Mesos-Agent container.
 
 ### Launch Exhibitor (Zookeeper)
 
@@ -55,9 +55,9 @@ docker run -d --net=host \
   mesosphere/mesos-master:0.28.0-2.0.16.ubuntu1404
 ```
 
-### Launch Mesos-Slave
+### Launch Mesos-Agent
 
-[Slave Configuration Reference](https://open.mesosphere.com/reference/mesos-slave/)
+[Agent Configuration Reference](https://open.mesosphere.com/reference/mesos-agent/)
 
 If the agent will make use of the Docker runtime, it can be configured in two different ways:
 * The agent can use its own Docker installation within the container, thus running Docker-in-Docker.
@@ -75,7 +75,7 @@ docker run -d --net=host --privileged \
   -v "$(pwd)/log/mesos:/var/log/mesos" \
   -v "$(pwd)/tmp/mesos:/var/tmp/mesos" \
   --entrypoint /bin/bash \
-  mesosphere/mesos-slave:0.28.0-2.0.16.ubuntu1404 -c "sudo service docker start; mesos-agent"
+  mesosphere/mesos-agent:0.28.0-2.0.16.ubuntu1404 -c "sudo service docker start; mesos-agent"
 ```
 
 To use the host system's Docker installation:
@@ -93,5 +93,5 @@ docker run -d --net=host --privileged \
   -v /cgroup:/cgroup \
   -v /sys:/sys \
   -v /usr/local/bin/docker:/usr/local/bin/docker \
-  mesosphere/mesos-slave:0.28.0-2.0.16.ubuntu1404
+  mesosphere/mesos-agent:0.28.0-2.0.16.ubuntu1404
 ```

--- a/mesos/dockerfile-templates/mesos-agent
+++ b/mesos/dockerfile-templates/mesos-agent
@@ -1,4 +1,4 @@
 FROM mesosphere/mesos:{VERSION}
 MAINTAINER Mesosphere <support@mesosphere.io>
 
-ENTRYPOINT ["mesos-slave"]
+ENTRYPOINT ["mesos-agent"]


### PR DESCRIPTION
This PR updates the Mesos Docker containers:
* Renames `slave` to `agent`
* Adds tagging of `latest` to the `Makefile` used to build Mesos containers
* Adds text about networking on OSX
* Adds text about Docker-in-Docker on the agent

Resolves #68 #61 