### PR TITLE
ENTRYPOINT was Replaced with CMD in mesos-slave Dockerfile

### DIFF
--- a/mesos/dockerfile-templates/mesos-slave
+++ b/mesos/dockerfile-templates/mesos-slave
@@ -1,4 +1,4 @@
 FROM mesosphere/mesos:{VERSION}
 MAINTAINER Mesosphere <support@mesosphere.io>
 
-ENTRYPOINT ["mesos-slave"]
+CMD ["mesos-slave"]


### PR DESCRIPTION
**Why ENTRYPOINT was replaced with CMD?**
In large clusters, many nodes will only have *mesos-slave* docker image on hosts. When docker containerizer is used, *mesos-slave* will start *mesos-execute* in a separate container and it will start your task in another container accordingly. Docker image for *mesos-execute* should be specified with `--docker_mesos_image` flag or `MESOS_DOCKER_MESOS_IMAGE` environment variable for *mesos-slave*. It is reasonable to set this flag/env. variable to *mesos-slave* docker image because you most probably want to pull lesser docker images for each host while setting up a dockerized Mesos cluster. 

So, when *mesos-slave* container is started with `--docker_mesos_image` pointing to `mesosphere/mesos-slave:<tag>` image, it tries to start *mesos-execute*, specifying it as a command to docker container. But, since `mesos-slave` Dockerfile uses  ENTRYPOINT command instead of CMD, *mesos-execute* container's start will fail (*mesos-execute* container will have the following command in this case: `mesos-slave mesos-execute ...flags...`). The use of CMD instead of ENTRYPOINT will fix the situation and entry command to *mesos-execute* container will be `mesos-execute ...flags...`.

There is a possible concern: if somebody relied on the ENTRYPOINT declaration for *mesos-slave* and included someting like `docker run ... mesosphere/mesos-slave:<tag> ...flags_for_mesos_slave...` in his scripts, then he should update these scripts with `docker run ... mesosphere/mesos-slave:<tag> mesos-slave ...flags_for_mesos_slave...` (`mesos-slave` added immediately after image name).

I would prefer to have a CMD command to be able to reuse `mesosphere/mesos-slave:<tag>` for *mesos-execute*. What do you think?
