### PR TITLE
Add dcos-commons-tls-nginx container

### DIFF
--- a/dcos-commons-tls-nginx/Dockerfile
+++ b/dcos-commons-tls-nginx/Dockerfile
@@ -1,0 +1,14 @@
+FROM nginx
+MAINTAINER Mesosphere Support <support@mesosphere.com>
+
+RUN apt-get update && \
+    rm -rf /etc/nginx/conf.d/* && \
+    sed -i 's/access_log.*/access_log \/dev\/stdout;/g' /etc/nginx/nginx.conf && \
+    sed -i 's/error_log.*/error_log \/dev\/stdout info;/g' /etc/nginx/nginx.conf && \
+    sed -i 's/^pid/daemon off;\npid/g' /etc/nginx/nginx.conf
+
+ADD ./assets/nginx.conf /etc/nginx/
+ADD ./assets/tls.conf /etc/nginx/conf.d/
+ADD ./assets/http.conf /etc/nginx/conf.d/
+
+CMD ['nginx']

--- a/dcos-commons-tls-nginx/Makefile
+++ b/dcos-commons-tls-nginx/Makefile
@@ -1,0 +1,11 @@
+NS = mesosphere
+NAME = dcos-commons-tls-nginx
+VERSION = latest
+
+.PHONY: build
+build:
+	docker build -t $(NS)/$(NAME):$(VERSION) -f Dockerfile .
+
+.PHONY: push
+push: build
+	docker push $(NS)/$(NAME):$(VERSION)

--- a/dcos-commons-tls-nginx/README.md
+++ b/dcos-commons-tls-nginx/README.md
@@ -1,0 +1,43 @@
+# dcos-commons nginx TLS
+
+This is a helper docker container image running an nginx server with
+`keystore-https.hello-world.l4lb.thisdcos.directory` name. The container is
+used within `dcos-commons` integration test suite.
+
+The `nginx` is configured to expose an HTTP webserver on port `80` which
+redirects requests to the port `443` with TLS. The container
+expects a certificate and a private key to be available in `/opt` directory
+on a container start.
+
+## Build
+
+Build a container locally
+
+```sh
+make build
+```
+
+Push a container to docker registry
+
+```sh
+make push
+```
+
+By default the container is being pushed to the `mesosphere` docker hub
+namespace. It is possible to build and push a container to custom namespace,
+container name and version.
+
+```
+make push NS=mhrabovcin NAME=my-nginx VERSION=0.1
+```
+
+## Run
+
+The `nginx` configuration depends on `/opt/site.key` and `/opt/site.crt` files
+to be provided to the container. Files can be mounted with `-v` flag. Without
+these files container will fail with following message:
+
+```
+2017/07/13 11:35:44 [emerg] 1#1: BIO_new_file("/opt/site.crt") failed (SSL: error:02001002:system library:fopen:No such file or directory:fopen('/opt/site.crt','r') error:2006D080:BIO routines:BIO_new_file:no such file)
+nginx: [emerg] BIO_new_file("/opt/site.crt") failed (SSL: error:02001002:system library:fopen:No such file or directory:fopen('/opt/site.crt','r') error:2006D080:BIO routines:BIO_new_file:no such file)
+```

--- a/dcos-commons-tls-nginx/assets/http.conf
+++ b/dcos-commons-tls-nginx/assets/http.conf
@@ -1,0 +1,13 @@
+server {
+    listen       80 default_server;
+    listen       [::]:80 default_server;
+    server_name  nginx-https.hello-world.l4lb.thisdcos.directory;
+    root         /usr/share/nginx/html;
+
+    if ($http_x_forwarded_proto = 'http') {
+    return 301 https://$server_name$request_uri;
+    }
+
+    location / {
+    }
+}

--- a/dcos-commons-tls-nginx/assets/nginx.conf
+++ b/dcos-commons-tls-nginx/assets/nginx.conf
@@ -1,0 +1,28 @@
+user nginx;
+worker_processes auto;
+error_log /var/log/nginx/error.log;
+pid /var/run/nginx.pid;
+daemon off;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+    access_log  /var/log/nginx/access.log  main;
+    sendfile            on;
+    tcp_nopush          on;
+    tcp_nodelay         on;
+    keepalive_timeout   65;
+    types_hash_max_size 2048;
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+    # Load modular configuration files from the /etc/nginx/conf.d directory.
+    # See http://nginx.org/en/docs/ngx_core_module.html#include
+    # for more information.
+    include /etc/nginx/conf.d/*.conf;
+    index   index.html index.htm;
+}

--- a/dcos-commons-tls-nginx/assets/tls.conf
+++ b/dcos-commons-tls-nginx/assets/tls.conf
@@ -1,0 +1,13 @@
+
+server {
+    listen              443 ssl;
+    server_name  nginx-https.hello-world.l4lb.thisdcos.directory;
+    ssl_certificate     /opt/site.crt;
+    ssl_certificate_key /opt/site.key;
+    ssl_protocols       TLSv1.2;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
+    root /usr/share/nginx/html;
+
+    location / {
+    }
+}


### PR DESCRIPTION
DCOS-17254 - Create a nginx docker container for testing TLS PEM certificates

This is a new container that will be used as part of `dcos-commons` TLS integration tests.

The container is published here https://hub.docker.com/r/mesosphere/dcos-commons-tls-nginx/