### PR TITLE
update versions for mesos containers

### DIFF
--- a/mesos/README.md
+++ b/mesos/README.md
@@ -52,7 +52,7 @@ docker run -d --net=host \
   -e MESOS_WORK_DIR=/var/tmp/mesos \
   -v "$(pwd)/log/mesos:/var/log/mesos" \
   -v "$(pwd)/tmp/mesos:/var/tmp/mesos" \
-  mesosphere/mesos-master:0.28.0-2.0.16.ubuntu1404
+  mesosphere/mesos-master:1.5.0
 ```
 
 ### Launch Mesos-Slave
@@ -73,5 +73,5 @@ docker run -d --net=host --privileged \
   -v /cgroup:/cgroup \
   -v /sys:/sys \
   -v /usr/local/bin/docker:/usr/local/bin/docker \
-  mesosphere/mesos-slave:0.28.0-2.0.16.ubuntu1404
+  mesosphere/mesos-slave:1.5.0
 ```


### PR DESCRIPTION
the current example will break on some newer systems with issues that were fixed in mesos

also I'm curious if we should add `no-systemd_enable_support` as it fixed another problem on my end (see [MESOS-3793](https://issues.apache.org/jira/browse/MESOS-3793))

Signed-off-by: Dominik Richter <dominik.richter@gmail.com>